### PR TITLE
add pipeline retiming

### DIFF
--- a/src/spatial/Spatial.scala
+++ b/src/spatial/Spatial.scala
@@ -25,7 +25,7 @@ protected trait SpatialExp extends Staging
   with DebuggingExp
 
   with ControllerExp with CounterExp with DRAMExp with FIFOExp with HostTransferExp with MathExp
-  with MemoryExp with ParameterExp with RangeExp with RegExp with SRAMExp with StagedUtilExp with UnrolledExp with VectorExp
+  with MemoryExp with ParameterExp with RangeExp with RegExp with ShiftRegExp with SRAMExp with StagedUtilExp with UnrolledExp with VectorExp
   with StreamExp with PinExp with AlteraVideoExp
   with LineBufferExp with RegisterFileExp with SwitchExp with StateMachineExp with EnabledPrimitivesExp
 
@@ -39,7 +39,7 @@ protected trait SpatialApi extends SpatialExp
   with DebuggingApi
 
   with ControllerApi with CounterApi with DRAMApi with FIFOApi with HostTransferApi with MathApi
-  with MemoryApi with ParameterApi with RangeApi with RegApi with SRAMApi with StagedUtilApi with UnrolledApi with VectorApi
+  with MemoryApi with ParameterApi with RangeApi with RegApi with ShiftRegApi with SRAMApi with StagedUtilApi with UnrolledApi with VectorApi
   with StreamApi with PinApi with AlteraVideoApi
   with LineBufferApi with RegisterFileApi with SwitchApi with StateMachineApi with EnabledPrimitivesApi
 
@@ -53,7 +53,7 @@ protected trait ScalaGenSpatial extends ScalaCodegen with ScalaFileGen
   with ScalaGenDebugging
 
   with ScalaGenController with ScalaGenCounter with ScalaGenDRAM with ScalaGenFIFO with ScalaGenHostTransfer with ScalaGenMath
-  with ScalaGenRange with ScalaGenReg with ScalaGenSRAM with ScalaGenUnrolled with ScalaGenVector
+  with ScalaGenRange with ScalaGenReg with ScalaGenShiftReg with ScalaGenSRAM with ScalaGenUnrolled with ScalaGenVector
   with ScalaGenStream
   with ScalaGenLineBuffer with ScalaGenRegFile with ScalaGenStateMachine {
 
@@ -140,6 +140,8 @@ protected trait SpatialCompiler extends CompilerCore with SpatialExp with Spatia
   lazy val rewriter       = new RewriteTransformer { val IR: self.type = self }
 
   lazy val unroller       = new UnrollingTransformer { val IR: self.type = self }
+
+  lazy val pipeRetimer    = new PipeRetimer { val IR: self.type = self }
 
   lazy val bufferAnalyzer = new BufferAnalyzer { val IR: self.type = self; def localMems = uctrlAnalyzer.localMems }
   lazy val streamAnalyzer = new StreamAnalyzer { 
@@ -240,6 +242,10 @@ protected trait SpatialCompiler extends CompilerCore with SpatialExp with Spatia
   passes += bufferAnalyzer    // Set top controllers for n-buffers
   passes += streamAnalyzer    // Set stream pipe children fifo dependencies
   passes += argMapper         // Get address offsets for each used DRAM object
+  passes += printer
+
+  // --- Pipeline retiming
+  passes += pipeRetimer
   passes += printer
 
   // --- Code generation

--- a/src/spatial/api/ShiftRegisters.scala
+++ b/src/spatial/api/ShiftRegisters.scala
@@ -1,0 +1,83 @@
+package spatial.api
+
+import argon.core.Staging
+import spatial.SpatialExp
+
+trait ShiftRegApi extends ShiftRegExp {
+  this: SpatialExp =>
+
+  def ShiftReg[T:Staged:Bits](size: Int)(implicit ctx: SrcCtx): ShiftReg[T] = ShiftReg(shift_reg_alloc[T](size, zero[T].s))
+  def ShiftReg[T:Staged:Bits](size: Int, init: T)(implicit ctx: SrcCtx): ShiftReg[T] = ShiftReg(shift_reg_alloc[T](size, init.s))
+
+  implicit def readShiftReg[T](shiftReg: ShiftReg[T])(implicit ctx: SrcCtx): T = shiftReg.value
+}
+
+
+trait ShiftRegExp extends Staging with MemoryExp {
+  this: SpatialExp =>
+
+  /** Infix methods **/
+  case class ShiftReg[T:Staged:Bits](s: Exp[ShiftReg[T]]) {
+    def value(implicit ctx: SrcCtx): T = wrap(shift_reg_read(this.s))
+    def :=(data: T)(implicit ctx: SrcCtx): Void = Void(shift_reg_write(this.s, data.s, bool(true)))
+  }
+
+  /** Staged Type **/
+  case class ShiftRegType[T:Bits](child: Staged[T]) extends Staged[ShiftReg[T]] {
+    override def unwrapped(x: ShiftReg[T]) = x.s
+    override def wrapped(x: Exp[ShiftReg[T]]) = ShiftReg(x)(child,bits[T])
+    override def typeArguments = List(child)
+    override def stagedClass = classOf[ShiftReg[T]]
+    override def isPrimitive = false
+  }
+  implicit def shiftRegType[T:Staged:Bits]: Staged[ShiftReg[T]] = ShiftRegType(typ[T])
+
+  class ShiftRegIsMemory[T:Staged:Bits] extends Mem[T, ShiftReg] {
+    def load(mem: ShiftReg[T], is: Seq[Index], en: Bool)(implicit ctx: SrcCtx): T = mem.value
+    def store(mem: ShiftReg[T], is: Seq[Index], data: T, en: Bool)(implicit ctx: SrcCtx): Void = {
+      Void(shift_reg_write(mem.s, data.s, en.s))
+    }
+    def iterators(mem: ShiftReg[T])(implicit ctx: SrcCtx): Seq[Counter] = Seq(Counter(0, sizeOf(mem), 1, 1))
+  }
+  implicit def shiftRegIsMemory[T:Staged:Bits]: Mem[T, ShiftReg] = new ShiftRegIsMemory[T]
+
+
+  /** IR Nodes **/
+  case class ShiftRegNew[T:Staged:Bits](size: Int, init: Exp[T]) extends Op[ShiftReg[T]] {
+    def mirror(f:Tx) = shift_reg_alloc[T](size, f(init))
+    val mT = typ[T]
+    val bT = bits[T]
+  }
+  case class ShiftRegRead[T:Staged:Bits](shiftReg: Exp[ShiftReg[T]]) extends Op[T] {
+    def mirror(f:Tx) = shift_reg_read(f(shiftReg))
+    val mT = typ[T]
+    val bT = bits[T]
+    override def aliases = Nil
+  }
+  case class ShiftRegWrite[T:Staged:Bits](shiftReg: Exp[ShiftReg[T]], data: Exp[T], en: Exp[Bool]) extends Op[Void] {
+    def mirror(f:Tx) = shift_reg_write(f(shiftReg),f(data), f(en))
+    val mT = typ[T]
+    val bT = bits[T]
+  }
+
+  /** Constructors **/
+  def shift_reg_alloc[T:Staged:Bits](size: Int, init: Exp[T])(implicit ctx: SrcCtx): Sym[ShiftReg[T]] = {
+    stageMutable( ShiftRegNew[T](size, init) )(ctx)
+  }
+
+  def shift_reg_read[T:Staged:Bits](shiftReg: Exp[ShiftReg[T]])(implicit ctx: SrcCtx): Sym[T] = stageCold( ShiftRegRead(shiftReg) )(ctx)
+
+  def shift_reg_write[T:Staged:Bits](shiftReg: Exp[ShiftReg[T]], data: Exp[T], en: Exp[Bool])(implicit ctx: SrcCtx): Sym[Void] = {
+    stageWrite(shiftReg)( ShiftRegWrite(shiftReg, data, en) )(ctx)
+  }
+
+
+  /** Internals **/
+  private def sizeOf(shiftReg: ShiftReg[_])(implicit ctx: SrcCtx): Int = sizeOf(shiftReg.s)
+  private def sizeOf[T](shiftReg: Exp[ShiftReg[T]])(implicit ctx: SrcCtx): Int = shiftReg match {
+    case Op(ShiftRegNew(size, init)) => size
+    case x => throw new UndefinedDimensionsError(x, None)
+  }
+
+}
+

--- a/src/spatial/codegen/scalagen/ScalaGenShiftReg.scala
+++ b/src/spatial/codegen/scalagen/ScalaGenShiftReg.scala
@@ -1,0 +1,22 @@
+package spatial.codegen.scalagen
+
+import argon.codegen.scalagen.ScalaCodegen
+import spatial.api.ShiftRegExp
+
+trait ScalaGenShiftReg extends ScalaCodegen {
+  val IR: ShiftRegExp
+  import IR._
+
+  override protected def remap(tp: Staged[_]): String = tp match {
+    case tp: ShiftRegType[_] => src"Array[${tp.child}]"
+    case _ => super.remap(tp)
+  }
+
+  override protected def emitNode(lhs: Sym[_], rhs: Op[_]): Unit = rhs match {
+    case ShiftRegNew(_, init)    => emit(src"val $lhs = Array($init)")
+    case ShiftRegRead(reg)    => emit(src"val $lhs = $reg.apply(0)")
+    case ShiftRegWrite(reg,v,en) => emit(src"val $lhs = if ($en) $reg.update(0, $v)")
+    case _ => super.emitNode(lhs, rhs)
+  }
+
+}

--- a/src/spatial/codegen/scalagen/ScalaGenShiftReg.scala
+++ b/src/spatial/codegen/scalagen/ScalaGenShiftReg.scala
@@ -13,7 +13,7 @@ trait ScalaGenShiftReg extends ScalaCodegen {
   }
 
   override protected def emitNode(lhs: Sym[_], rhs: Op[_]): Unit = rhs match {
-    case ShiftRegNew(_, init)    => emit(src"val $lhs = Array($init)")
+    case op@ShiftRegNew(_, init)    => emit(src"val $lhs = ${op.mR}($init)")
     case ShiftRegRead(reg)    => emit(src"val $lhs = $reg.apply(0)")
     case ShiftRegWrite(reg,v,en) => emit(src"val $lhs = if ($en) $reg.update(0, $v)")
     case _ => super.emitNode(lhs, rhs)

--- a/src/spatial/transform/PipeRetimer.scala
+++ b/src/spatial/transform/PipeRetimer.scala
@@ -1,0 +1,183 @@
+package spatial.transform
+
+import scala.collection.mutable
+
+import argon.transform.ForwardTransformer
+import spatial.SpatialExp
+
+trait PipeRetimer extends ForwardTransformer {
+  val IR: SpatialExp
+  import IR._
+
+  override val name = "Pipeline Retimer"
+
+  private def retimeBlock[T:Staged](block: Block[T])(implicit ctx: SrcCtx): Exp[T] = inlineBlock(block, {stms =>
+    val tab = "  "
+    dbg(c"Retiming block $block")
+    // cache symbol latencies to avoid recalculating if they've already been encountered during the traversal
+    val latencyCache = mutable.HashMap[Sym[_], Int]()
+
+    // perform recursive search of inputs to determine cumulative symbol latency
+    def symLatency(sym: Sym[_]): Int = if (block.inputs.contains(sym)) 0 else {
+      def opLatency(d: Def): Int = d match {
+        //case _: FixAdd[_,_,_] => 3
+        //case _: FixMul[_,_,_] => 5
+        //case _: FixDiv[_,_,_] => 7
+        case _ => 0
+      }
+
+      val inputs = onlySyms(defOf(sym).inputs)
+      val inputLatency = if (inputs.isEmpty) 0 else {
+        inputs.map{ s => latencyCache.getOrElseUpdate(s, symLatency(s))}.max
+      }
+      inputLatency + opLatency(defOf(sym))
+    }
+
+    // track register info for each retimed reader
+    class ReaderInfo(val size: Int) {
+      // size represents the total buffer size between reader and input symbol
+      // if buffers are split, the size of the register for this reader may actually be smaller
+
+      // register this reader symbol reads from
+      var reg: Exp[ShiftReg[_]] = _
+      // register read IR node (not strictly neccesary to have only one but it avoids bloating the IR with redundant reads)
+      var read: Exp[_] = _
+    }
+
+    // track reader dependencies associated with an input
+    class InputInfo {
+      // map a reader symbol to the buffer it will read from
+      val readers = mutable.HashMap[Sym[_], ReaderInfo]()
+      // group readers by the size of the register they read from
+      object RegSizeOrdering extends Ordering[Int] { def compare(a: Int, b: Int) = b compare a }
+      val readerSizes = mutable.SortedMap[Int, mutable.Set[Sym[_]]]()(RegSizeOrdering)
+ 
+      // retime symbol readers, sharing allocated buffers when possible
+      def retimeReaders[U](input: Sym[U]) {
+        def regAlloc[T](s: Exp[T], size: Int)(implicit ctx: SrcCtx): Exp[ShiftReg[T]] = s.tp match {
+          case Bits(bits) =>
+            val init = unwrap(bits.zero)(s.tp)
+            shift_reg_alloc[T](size, init)(s.tp, bits, ctx)
+          case _ => throw new Exception("Unexpected register type")
+        }
+
+        def regRead[T](reg: Exp[ShiftReg[T]])(implicit ctx: SrcCtx): Exp[T] = reg.tp.typeArguments.head match {
+          case tp @ Bits(bits) =>
+            shift_reg_read(reg)(mtyp(tp), mbits(bits), ctx)
+          case _ => throw new Exception("Unexpected register type")
+        }
+
+        def regWrite[T](reg: Exp[ShiftReg[_]], s: Exp[T])(implicit ctx: SrcCtx): Exp[Void] = s.tp match {
+          case Bits(bits) =>
+            shift_reg_write(reg.asInstanceOf[Exp[ShiftReg[T]]], s, bool(true))(s.tp, bits, ctx)
+          case _ => throw new Exception("Unexpected register type")
+        }
+
+        // group and sort all the register sizes dependent symbols read from
+        val sizes = readers.map{ case (reader, info) => info.size }.toList.sorted
+        // calculate register allocation sizes after coalescing
+        val sizesCoalesced = (0 :: sizes).sliding(2).map{ case List(a, b) => b - a}.toList
+        // map a reader's total register size to the size of the immediate register it will read from after coalescing
+        val regSizeMap = sizes.zip(sizesCoalesced).toMap
+        readers.foreach{ case (reader, info) =>
+          readerSizes.getOrElseUpdate(regSizeMap(info.size), mutable.Set[Sym[_]]()) += reader
+        }
+
+        dbg(tab + c"Allocating registers for input $input")
+        val regReads = mutable.ListBuffer[Exp[_]](input)
+        // add sequential reads/writes between split registers after coalescing
+        readerSizes.foreach{ case (size, readersSet) =>
+          val reg = regAlloc(input, size)
+          regWrite(reg, f(regReads.last))
+          val read = regRead(reg)
+          readersSet.foreach{ case reader =>
+            dbg(tab + c"  Register: $reg, size: $size, reader: $reader")
+            readers(reader).reg = reg
+            readers(reader).read = read
+          }
+          regReads += read
+        }
+      }
+    }
+
+    // enumerate symbol reader dependencies and calculate required buffer sizes
+    val inputRetiming = mutable.HashMap[Sym[_], InputInfo]()
+    stms.foreach{ case stm @ TP(reader, d) =>
+      // inputs that are written to need to be filtered
+      val inputs = onlySyms(d.inputs).toSet.diff(effectsOf(reader).writes)
+      val inputLatencies = inputs.map{ sym => symLatency(sym) }
+      // calculate buffer register size for each input symbol
+      val sizes = inputLatencies.map{ latency => inputLatencies.max - latency }
+      // discard symbols for which no register insertion is needed
+      val inputsSizes = inputs.zip(sizes).filter{ case (sym, size) => size != 0 }
+      inputsSizes.foreach{ case (input, size) =>
+        inputRetiming.getOrElseUpdate(input, new InputInfo()).readers.getOrElseUpdate(reader, new ReaderInfo(size))
+      }
+    }
+
+    // record which inputs have been buffered so retiming occurs only once
+    val retimedInputs = mutable.Set[Sym[_]]()
+    // traverse the IR, inserting registers allocated above
+    stms.foreach{ case stm @ TP(reader, d) =>
+      // save substitution rules for restoration after transformation
+      val subRules = mutable.Map[Sym[_], Exp[_]]()
+
+      val inputs = onlySyms(d.inputs)
+      inputs.foreach{ case input =>
+        // input might not need any buffers if its readers don't need to be retimed
+        if (inputRetiming.contains(input)) {\
+          // retime all readers of this input and mark the input itself as retimed
+          if (!retimedInputs.contains(input)) {
+            inputRetiming(input).retimeReaders(input)
+            retimedInputs += input
+          }
+          // insert buffer register for this reader
+          if (inputRetiming(input).readers.contains(reader)) {
+            val info = inputRetiming(input).readers(reader)
+            dbg(tab + c"Buffering input $input to reader $reader")
+            subRules(input) = subst(input)
+            register(input, info.read)
+          }
+        }
+      }
+      visitStm(stm)
+      // restore substitution rules since future instances of this input may not be retimed in the same way
+      subRules.foreach{ case (a, b) => register(a,b) }
+    }
+
+    val result = typ[T] match {
+      case VoidType => void
+      case _ => f(block.result)
+    }
+    result.asInstanceOf[Exp[T]]
+  })
+
+  var retimeBlocks: Boolean = false
+  var ctx: Option[SrcCtx] = None
+  def withRetime[A](srcCtx: SrcCtx)(x: => A) = {
+    val prevRetime = retimeBlocks
+    val prevCtx = ctx
+    retimeBlocks = true
+    ctx = Some(srcCtx)
+    val result = x
+    retimeBlocks = prevRetime
+    ctx = prevCtx
+    result
+  }
+
+  override def apply[T:Staged](b: Block[T]): Exp[T] = {
+    if (retimeBlocks) {
+      retimeBlocks = false
+      val result = retimeBlock(b)(mtyp(b.tp),ctx.get)
+      result
+    }
+    else super.apply(b)
+  }
+
+  override def transform[T:Staged](lhs: Sym[T], rhs: Op[T])(implicit ctx: SrcCtx): Exp[T] = {
+    if (isInnerControl(lhs))
+      withRetime(ctx){ super.transform(lhs, rhs) }
+    else
+      super.transform(lhs, rhs)
+  }
+}

--- a/src/spatial/transform/PipeRetimer.scala
+++ b/src/spatial/transform/PipeRetimer.scala
@@ -125,7 +125,7 @@ trait PipeRetimer extends ForwardTransformer {
       val inputs = onlySyms(d.inputs)
       inputs.foreach{ case input =>
         // input might not need any buffers if its readers don't need to be retimed
-        if (inputRetiming.contains(input)) {\
+        if (inputRetiming.contains(input)) {
           // retime all readers of this input and mark the input itself as retimed
           if (!retimedInputs.contains(input)) {
             inputRetiming(input).retimeReaders(input)
@@ -135,7 +135,7 @@ trait PipeRetimer extends ForwardTransformer {
           if (inputRetiming(input).readers.contains(reader)) {
             val info = inputRetiming(input).readers(reader)
             dbg(tab + c"Buffering input $input to reader $reader")
-            subRules(input) = subst(input)
+            subRules(input) = transformExp(input)(mtyp(input.tp))
             register(input, info.read)
           }
         }

--- a/test/spatial/tests/UnitTests.scala
+++ b/test/spatial/tests/UnitTests.scala
@@ -1,6 +1,6 @@
 package spatial.tests
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers,Tag}
 import spatial._
 import org.virtualized._
 
@@ -590,6 +590,32 @@ object UnalignedLd extends SpatialTest {
   }
 }
 
+object PipeRetimer extends Tag("PipeRetimer") with SpatialTest {
+  import IR._
+  @virtualize
+  def main() {
+    // add one to avoid dividing by zero
+    val a = random[Int](10) + 1
+    val b = random[Int](10) + 1
+
+    val aIn = ArgIn[Int]
+    val bIn = ArgIn[Int]
+    setArg(aIn, a)
+    setArg(bIn, b)
+
+    val out1 = ArgOut[Int]
+    val out2 = ArgOut[Int]
+    Accel {
+      out1 := (aIn * bIn) + aIn
+      out2 := (aIn / bIn) + aIn
+    }
+    val gold1 = (a * b) + a
+    val gold2 = (a / b) + a
+    val cksum = gold1 == getArg(out1) && gold2 == getArg(out2)
+    println("PASS: " + cksum + " (PipeRetimer)")
+  }
+}
+
 class UnitTests extends FlatSpec with Matchers {
   SpatialConfig.enableScala = true
   "SimpleSequential" should "compile" in { SimpleSequential.main(Array.empty) }
@@ -604,4 +630,5 @@ class UnitTests extends FlatSpec with Matchers {
   "Memcpy2D" should "compile" in { Memcpy2D.main(Array.empty) }
   "BlockReduce1D" should "compile" in { BlockReduce1D.main(Array.empty) }
   "UnalignedLd" should "compile" in { UnalignedLd.main(Array.empty) }
+  "PipeRetimer" should "compile" taggedAs(PipeRetimer) in { PipeRetimer.main(Array.empty) }
 }


### PR DESCRIPTION
This pull request contains all the basic changes for pipeline retiming, and I've worked out all the bugs I could find so far. At the moment, I'm working on the chisel codegen so I can test it with a clock cycle level model.

For the moment, retiming is disabled (opLatency(d: Def) always returns 0); I still need to discuss with David cases where nodes don't use Bits type.