### PR TITLE
urgent: Remove spatial/* from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ project/plugins/project/
 tags
 docs/build/*
 spatial/core/resources/chiselgen/template-level/test_run_dir/templates*
-spatial/*
 
 # Scala-IDE specific
 .scala_dependencies


### PR DESCRIPTION
Why was this added in the first place ?
All my changes to spatial were subsequently ignored