### PR TITLE
Add ZCU102 DeviceTarget in Chisel generator's Util.scala template.

### DIFF
--- a/spatial/core/resources/chiselgen/template-level/templates/Utils.scala
+++ b/spatial/core/resources/chiselgen/template-level/templates/Utils.scala
@@ -13,6 +13,7 @@ object Zynq extends DeviceTarget
 object DE1 extends DeviceTarget // Do not use this one
 object de1soc extends DeviceTarget
 object AWS_F1 extends DeviceTarget
+object ZCU102 extends DeviceTarget
 
 object ops {
 
@@ -179,6 +180,7 @@ object ops {
           case Zynq => b*c // Raghu's box
           case DE1 => b*c // Raghu's box
           case `de1soc` => b*c // Raghu's box
+          case ZCU102 => b*c
           case Default => b*c
         }
       }
@@ -194,6 +196,7 @@ object ops {
           case Zynq => b.asSInt*c // Raghu's box
           case DE1 => b.asSInt*c // Raghu's box
           case `de1soc` => b.asSInt*c // Raghu's box
+          case ZCU102 => b.asSInt*c
           case Default => b.asSInt*c
         }
       }
@@ -225,6 +228,7 @@ object ops {
          case Zynq => FringeGlobals.bigIP.divide(b, c, (Utils.fixdiv_latency * b.getWidth).toInt) 
          case DE1 => b/c // Raghu's box
         case `de1soc` => b/c // Raghu's box
+         case ZCU102 => b/c
          case Default => b/c
        }
      }
@@ -240,6 +244,7 @@ object ops {
          case Zynq => b.asSInt/c // Raghu's box
          case DE1 => b.asSInt/c // Raghu's box
          case `de1soc` => b.asSInt/c // Raghu's box
+         case ZCU102 => b.asSInt/c
          case Default => b.asSInt/c
        }
      }
@@ -276,6 +281,7 @@ object ops {
           case Zynq => b%c // Raghu's box
           case DE1 => b%c // Raghu's box
           case `de1soc` => b%c // Raghu's box
+          case ZCU102 => b%c
           case Default => b%c
         }
       }
@@ -292,6 +298,7 @@ object ops {
           case Zynq => b.asSInt%c // Raghu's box
           case DE1 => b.asSInt%c // Raghu's box
           case `de1soc` => b.asSInt%c // Raghu's box
+          case ZCU102 => b.asSInt%c
           case Default => b.asSInt%c
         }
       }
@@ -393,6 +400,7 @@ object ops {
           case Zynq => b*c.asSInt // Raghu's box
           case DE1 => b*c.asSInt // Raghu's box
           case `de1soc` => b*c.asSInt // Raghu's box
+          case ZCU102 => b*c.asSInt
           case Default => b*c.asSInt
         }
       }
@@ -408,6 +416,7 @@ object ops {
           case Zynq => b*c // Raghu's box
           case DE1 => b*c // Raghu's box
           case `de1soc` => b*c // Raghu's box
+          case ZCU102 => b*c
           case Default => b*c
         }
       }
@@ -441,6 +450,7 @@ object ops {
          case Zynq => b/c.asSInt // Raghu's box
          case DE1 => b/c.asSInt // Raghu's box
          case `de1soc` => b/c.asSInt // Raghu's box
+          case ZCU102 => b/c.asSInt
          case Default => b/c.asSInt
        }
      }
@@ -456,6 +466,7 @@ object ops {
          case Zynq => b/c // Raghu's box
          case DE1 => b/c // Raghu's box
          case `de1soc` => b/c // Raghu's box
+          case ZCU102 => b/c
          case Default => b/c
        }
      }
@@ -491,6 +502,7 @@ object ops {
           case Zynq => b%c.asSInt // Raghu's box
           case DE1 => b%c.asSInt // Raghu's box
           case `de1soc` => b%c.asSInt // Raghu's box
+          case ZCU102 => b%c.asSInt
           case Default => b%c.asSInt
         }
       }
@@ -506,6 +518,7 @@ object ops {
           case Zynq => b%c // Raghu's box
           case DE1 => b%c // Raghu's box
           case `de1soc` => b%c // Raghu's box
+          case ZCU102 => b%c
           case Default => b%c
         }
       }


### PR DESCRIPTION
Building a Quicktest app for Xilinx ZCU102 Ultrascale+ board failed in the "make zcu-hw" step with the following error:

[info] Compiling 117 Scala sources to /data/experiment/arch/spatial/spatial-lang/gen/Quicktest_zynq/target/scala-2.11/classes ...
[error] /data/experiment/arch/spatial/spatial-lang/gen/Quicktest_zynq/chisel/IOModule.scala:48:18: not found: value ZCU102
[error]   Utils.target = ZCU102
[error]                  ^
[error] one error found
[error] (Compile / compileIncremental) Compilation failed

Tracing back to the Chisel generator template used to generate this file, the declaration of DeviceTarget for ZCU102 was not added in Utils.scala. Simply adding the DeviceTarget declaration resulted in successful compilation.

Tested by executing the generated application on Xilinx ZCU102 Ultrascale+ ES2 board.